### PR TITLE
Make example cert store be the default location

### DIFF
--- a/articles/virtual-machines/extensions/key-vault-linux.md
+++ b/articles/virtual-machines/extensions/key-vault-linux.md
@@ -124,7 +124,7 @@ The following JSON shows the schema for the Key Vault VM extension. The extensio
 | pollingIntervalInS | 3600 | string |
 | certificateStoreName | It is ignored on Linux | string |
 | linkOnRenewal | false | boolean |
-| certificateStoreLocation  | /var/lib/waagent/Microsoft.Azure.KeyVault | string |
+| certificateStoreLocation  | /var/lib/waagent/Microsoft.Azure.KeyVault.Store | string |
 | requireInitialSync | true | boolean |
 | observedCertificates  | ["https://myvault.vault.azure.net/secrets/mycertificate", "https://myvault.vault.azure.net/secrets/mycertificate2"] | string array
 | msiEndpoint | http://169.254.169.254/metadata/identity | string |


### PR DESCRIPTION
The default location is in the document but buried.  Let's make the example be the default.